### PR TITLE
luci-app-pbr: Ignore WireGuard Server if on ignored list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.1.8
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-pbr/

--- a/po/templates/pbr.pot
+++ b/po/templates/pbr.pot
@@ -47,14 +47,15 @@ msgstr ""
 msgid ""
 "Allows to specify the list of interface names (in lower case) to be "
 "explicitly supported by the service. Can be useful if your OpenVPN tunnels "
-"have dev option other than tun* or tap*."
+"have dev option other than tun* or tap*, or have a WireGuard server which "
+"also functions as a client (site-to-site)."
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:155
 msgid ""
-"Allows to specify the list of interface names (in lower case) to be ignored "
-"by the service. Can be useful if running both VPN server and VPN client on "
-"the router."
+"Allows to specify the list of interface names (lower case) to be ignored by "
+"the service. Can be useful for an OpenVPN server. WireGuard servers, which "
+"have a listenport, are handled automatically. So do not add those here."
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:43


### PR DESCRIPTION
This is the accompanying PR for: https://github.com/stangri/pbr/pull/29

This updates the help text, the read.me should probably also needs updating.

As this PR changes previous behavior I am not sure if this is the optimal solution, so feel free to change/improve  or discard this pull request.

It only updates the template, the translations should also need updating not sure if that is done automatically?