### PR TITLE
Don't resolve names in `is_running_iptables` check

### DIFF
--- a/root/usr/libexec/rpcd/luci.pbr
+++ b/root/usr/libexec/rpcd/luci.pbr
@@ -22,7 +22,7 @@ else
 fi
 
 # compatibility with old luci app versions
-is_running_iptables() { iptables -t mangle -L | grep -q PBR_PREROUTING >/dev/null 2>&1; }
+is_running_iptables() { iptables -t mangle -n -L | grep -q PBR_PREROUTING >/dev/null 2>&1; }
 is_running() { is_running_iptables || is_running_nft; }
 check_ipset() { { [ -n "$ipset" ] && "$ipset" help hash:net; } >/dev/null 2>&1; }
 check_agh_ipset() {


### PR DESCRIPTION
I have some iptables rules in mangle chain with IPs that don't resolve properly. Without the `-n` flag, ubus request hits a timeout and luci admin page fails to load.