### PR TITLE
Add uplink_ip_rules_priority configuration option

### DIFF
--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -228,6 +228,21 @@ return view.extend({
 		o.datatype = "hexstring";
 
 		o = s.taboption(
+			"tab_advanced",
+			form.Value,
+			"uplink_ip_rules_priority",
+			_("Uplink IP Rules Priority"),
+			_(
+				"Starting (Uplink/WAN) ip rules priority used by the pbr service. High starting priority is " +
+					"used to avoid conflict with other services, this can be changed by user."
+			)
+		);
+		o.rmempty = true;
+		o.placeholder = "30000";
+		o.datatype = "uinteger";
+		o.default = "30000";
+
+		o = s.taboption(
 			"tab_webui",
 			form.ListValue,
 			"webui_show_ignore_target",


### PR DESCRIPTION
Implement the uplink_ip_rules_priority option in the Advanced Configuration tab. This option allows users to configure the starting IP rules priority used by the pbr service for WAN/uplink interfaces. The default value is 30000.

The option was documented but missing from the UI. This change adds it to match the pbr service configuration option name (uplink_ip_rules_priority).

[Fixes #9](https://github.com/stangri/luci-app-pbr/issues/9)