### PR TITLE
Update interface names description in pbr.pot

### DIFF
--- a/po/templates/pbr.pot
+++ b/po/templates/pbr.pot
@@ -45,15 +45,15 @@ msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:144
 msgid ""
-"Allows to specify the list of interface names (in lower case) to be "
-"explicitly supported by the service. Can be useful if your OpenVPN tunnels "
+"Allows to specify the list of interface names to be explicitly "
+"supported by the service. Can be useful if your OpenVPN tunnels "
 "have dev option other than tun* or tap* or specific use cases of WireGuard "
 "servers. See the %sREADME%s for details."
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:160
 msgid ""
-"Allows to specify the list of interface names (lower case) to be ignored by "
+"Allows to specify the list of interface names to be ignored by "
 "the service. Can be useful for an OpenVPN server running on OpenWrt device. "
 "WireGuard servers, which have a listen_port defined, are handled "
 "automatically, do not add those here.See the %sREADME%s for details."


### PR DESCRIPTION
interface names for `supported interfaces` and `ignored interfaces` are case sensitive.
So redact the help text and remove the instruction to use `lower case`