### PR TITLE
Add gateway/gateway6 options to policies

### DIFF
--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -420,6 +420,12 @@ var status = baseclass.extend({
 					errorPolicyUnknownInterface: _(
 						"Policy '%s' has an unknown interface",
 					),
+					errorPolicyGatewayInvalid: _(
+						"Policy '%s' has an invalid gateway override",
+					),
+					errorPolicyGatewayUnsupportedMode: _(
+						"Policy '%s' uses gateway override with an unsupported routing-table mode",
+					),
 					errorPolicyProcessCMD: _("%s"),
 					errorFailedSetup: _("Failed to set up '%s'"),
 					errorFailedReload: _("Failed to reload '%s'"),

--- a/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/htdocs/luci-static/resources/view/pbr/overview.js
@@ -355,6 +355,36 @@ return view.extend({
 		});
 		o.datatype = "network";
 		o.rmempty = false;
+		o.textvalue = function (section_id) {
+			var iface = this.cfgvalue(section_id),
+				gateways = [
+					L.uci.get(pkg.Name, section_id, "gateway"),
+					L.uci.get(pkg.Name, section_id, "gateway6"),
+				].filter(function (gateway) {
+					return gateway != null && gateway !== "";
+				});
+
+			if (gateways.length)
+				return "%s (%s)".format(iface, _("via %s").format(gateways.join(", ")));
+
+			return iface;
+		};
+
+		o = s.option(form.Value, "gateway", _("IPv4 gateway override"));
+		o.datatype = "ip4addr";
+		o.placeholder = "10.0.0.1";
+		o.rmempty = true;
+		o.default = "";
+		o.modalonly = true;
+
+		if (L.uci.get(pkg.Name, "config", "ipv6_enabled") === "1") {
+			o = s.option(form.Value, "gateway6", _("IPv6 gateway override"));
+			o.datatype = "ip6addr";
+			o.placeholder = "2001:db8::1";
+			o.rmempty = true;
+			o.default = "";
+			o.modalonly = true;
+		}
 
 		s = m.section(
 			form.GridSection,

--- a/po/templates/pbr.pot
+++ b/po/templates/pbr.pot
@@ -210,8 +210,16 @@ msgstr ""
 msgid "Grant UCI and file access for luci-app-pbr"
 msgstr ""
 
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:373
+msgid "IPv4 gateway override"
+msgstr ""
+
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:119
 msgid "IPv6 Support"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:381
+msgid "IPv6 gateway override"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:144
@@ -399,6 +407,10 @@ msgstr ""
 msgid "Policy '%s' has an unknown interface"
 msgstr ""
 
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:423
+msgid "Policy '%s' has an invalid gateway override"
+msgstr ""
+
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:416
 msgid "Policy '%s' has no assigned DNS"
 msgstr ""
@@ -414,6 +426,10 @@ msgstr ""
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:465
 msgid ""
 "Policy '%s' refers to URL which can't be downloaded in 'secure_reload' mode"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:426
+msgid "Policy '%s' uses gateway override with an unsupported routing-table mode"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:11
@@ -498,7 +514,7 @@ msgstr ""
 msgid "Rule Create option"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:432
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:446
 msgid ""
 "Run the following user files after setting up but before restarting DNSMASQ. "
 "See the %sREADME%s for details."
@@ -520,6 +536,10 @@ msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:162
 msgid "Select Add for -A/add and Insert for -I/Insert."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:368
+msgid "via %s"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:660


### PR DESCRIPTION
This is the corresponding PR for [pbr/#90](https://github.com/mossdef-org/pbr/pull/99)

`gateway6` is only shown when Ipv6 is enabled. 

Screenshots:
<img width="2045" height="1336" alt="image" src="https://github.com/user-attachments/assets/f471480e-abd3-482a-8b35-9519b4ff4487" />
<img width="2256" height="678" alt="image" src="https://github.com/user-attachments/assets/ffc73889-7452-44bd-866c-78c72dd491f4" />

