### PR TITLE
luci-app-pbr-1.2.2: add new gateway warning and bumped compat

### DIFF
--- a/htdocs/luci-static/resources/pbr/status.js
+++ b/htdocs/luci-static/resources/pbr/status.js
@@ -11,7 +11,7 @@ var pkg = {
 		return "pbr";
 	},
 	get LuciCompat() {
-		return 25;
+		return 26;
 	},
 	get ReadmeCompat() {
 		return "1.2.2";
@@ -329,6 +329,9 @@ var status = baseclass.extend({
 					),
 					warningTorUnsetChainNft: _(
 						"Please unset 'chain' or set 'chain' to 'prerouting' for policy '%s'",
+					),
+					warningInterfaceRoutingUnknownGateway: _(
+						"Unknown Gateway for device '%s'",
 					),
 					warningInvalidOVPNConfig: _(
 						"Invalid OpenVPN config for %s interface",

--- a/root/usr/libexec/rpcd/luci.pbr
+++ b/root/usr/libexec/rpcd/luci.pbr
@@ -10,7 +10,7 @@
 # ubus -S call luci.pbr getPlatformSupport '{"name": "pbr" }'
 # ubus -S call luci.pbr getInterfaces '{"name": "pbr" }'
 
-readonly rpcdCompat='25'
+readonly rpcdCompat='26'
 readonly pbrFunctionsFile="${IPKG_INSTROOT}/etc/init.d/pbr"
 if [ -s "$pbrFunctionsFile" ]; then
 # shellcheck source=../../../../../pbr/files/etc/init.d/pbr


### PR DESCRIPTION
Add new warning: `warningInterfaceRoutingUnknownGateway`

Bumped Compat version in status.js and rpcd/luci.pbr